### PR TITLE
feat: adding waf and update tests

### DIFF
--- a/.github/workflows/ci_test.yaml
+++ b/.github/workflows/ci_test.yaml
@@ -14,7 +14,7 @@ jobs:
           # - k3s release channels at https://github.com/k3s-io/k3s/blob/HEAD/channel.yaml
           # - k3s versions at https://github.com/k3s-io/k3s/tags
           # - helm versions at https://github.com/helm/helm/tags
-          k3s-version: v1.27.2+k3s1
+          k3s-version: v1.27.5+k3s1
           helm-version: v3.11.2
           metrics-enabled: false
           traefik-enabled: false
@@ -31,9 +31,9 @@ jobs:
       - name: Install
         env:
           KUBE_LINTER_VER: 0.6.4
-          KUBE_SCORE_VER: 1.16.1
-          POLARIS_VER: 8.0.0
-          KUBECONFORM_VER: 0.6.2
+          KUBE_SCORE_VER: 1.17.0
+          POLARIS_VER: 8.5.1
+          KUBECONFORM_VER: 0.6.3
         run: |
           sudo apt-get update -yqq
           sudo apt-get install -yqq yamllint wget
@@ -65,9 +65,10 @@ jobs:
           helm repo add kedacore https://kedacore.github.io/charts
           helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
           helm repo update
-          helm install external-secrets external-secrets/external-secrets --version 0.8.3 --wait
-          helm install keda kedacore/keda --version 2.10.2 --wait
+          helm install external-secrets external-secrets/external-secrets --version 0.9.5 --wait
+          helm install keda kedacore/keda --version 2.11.2 --wait
           helm install prometheus prometheus-community/prometheus-operator-crds --wait
+          kubectl apply -f https://raw.githubusercontent.com/GlueOps/metacontroller-operator-waf/main/manifests/crd.yaml
           helm list
 
       - name: Checks

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,4 +1,4 @@
 name: app
 apiVersion: v2
 description: A Helm chart template for applications
-version: 0.3.0
+version: 0.4.0

--- a/examples/.polaris.yaml
+++ b/examples/.polaris.yaml
@@ -6,7 +6,7 @@ checks:
   pullPolicyNotAlways: ignore
   readinessProbeMissing: danger
   livenessProbeMissing: danger
-  metadataAndNameMismatched: danger
+  #metadataAndNameMismatched: danger
   pdbDisruptionsIsZero: danger
   missingPodDisruptionBudget: danger
   topologySpreadConstraint: danger
@@ -43,3 +43,4 @@ checks:
   clusterrolebindingClusterAdmin: warning
   rolebindingClusterAdminClusterRole: warning
   rolebindingClusterAdminRole: warning
+  metadataAndInstanceMismatched: warning

--- a/examples/test.sh
+++ b/examples/test.sh
@@ -23,7 +23,7 @@ for d in */ ; do
   echo "[INFO] yamllint on directory: $(pwd)"
   helm template ../../ -f ../../values.yaml -f values.yaml | yamllint -c ../.yamllint.yaml -
   echo "[INFO] kubeconform on directory: $(pwd)"
-  helm template ../../ -f ../../values.yaml -f values.yaml | kubeconform -summary -skip=ExternalSecret,TriggerAuthentication,ScaledObject -
+  helm template ../../ -f ../../values.yaml -f values.yaml | kubeconform -summary -skip=ExternalSecret,TriggerAuthentication,ScaledObject,WebApplicationFirewall -
   echo "[INFO] kube-linter on directory: $(pwd)"
   helm template ../../ -f ../../values.yaml -f values.yaml | kube-linter lint --config ../.kube-linter.yaml -
   echo "[INFO] kube-score on directory: $(pwd)"
@@ -31,7 +31,7 @@ for d in */ ; do
   echo "[INFO] polaris on directory: $(pwd)"
   polaris audit --set-exit-code-on-danger --only-show-failed-tests -f pretty --config ../.polaris.yaml --helm-chart ../../ --helm-values values.yaml
   echo "[INFO] kubeval on directory: $(pwd)"
-  helm template ../../ -f ../../values.yaml -f values.yaml | kubeval --kubernetes-version $KUBE_VER_FULL --schema-location https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master --skip-kinds=ExternalSecret --skip-kinds=TriggerAuthentication --skip-kinds=ScaledObject
+  helm template ../../ -f ../../values.yaml -f values.yaml | kubeval --kubernetes-version $KUBE_VER_FULL --schema-location https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master --skip-kinds=ExternalSecret --skip-kinds=TriggerAuthentication --skip-kinds=ScaledObject --skip-kinds=WebApplicationFirewall
   echo "[INFO] kubectl dry-run on directory: $(pwd)"
   helm template ../../ -f ../../values.yaml -f values.yaml |  kubectl apply --dry-run='client' -f - 
   

--- a/examples/waf/values.yaml
+++ b/examples/waf/values.yaml
@@ -1,4 +1,4 @@
-webApplicationFirewall:
+waf:
   enabled: true
   entries:
     - name: examplewafone

--- a/examples/webapplicationfirewall/values.yaml
+++ b/examples/webapplicationfirewall/values.yaml
@@ -1,0 +1,8 @@
+webApplicationFirewall:
+  enabled: true
+  entries:
+    - name: examplewafone
+      hosts:
+        - hostname: "example.com"
+        - hostname: "*.example.com" 
+      webAclName: "block-bad-networks-and-rate-limit"

--- a/templates/waf.yaml
+++ b/templates/waf.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.webApplicationFirewall.enabled -}}
+{{- range .Values.webApplicationFirewall.entries }}
+---
+apiVersion: metacontroller.glueops.dev/v1alpha1
+kind: WebApplicationFirewall
+metadata:
+  name: {{ include "app.name" $ }}-{{ .name }}
+  namespace: {{ include "app.namespace" $ }}
+spec:
+  domains:
+  {{- range .hosts }}
+    - {{ .hostname | quote }}
+  {{- end }}
+  {{- if .webAclName }}
+  web_acl_name: {{ .webAclName | quote }}
+  {{- end }}
+  {{- if .customCertificateSecretStorePath }}
+  custom_certificate_secret_store_path: {{ .customCertificateSecretStorePath | quote }}
+  {{- end }}
+{{- end }}
+{{- end }}

--- a/templates/waf.yaml
+++ b/templates/waf.yaml
@@ -1,5 +1,5 @@
-{{- if .Values.webApplicationFirewall.enabled -}}
-{{- range .Values.webApplicationFirewall.entries }}
+{{- if .Values.waf.enabled -}}
+{{- range .Values.waf.entries }}
 ---
 apiVersion: metacontroller.glueops.dev/v1alpha1
 kind: WebApplicationFirewall

--- a/tests/waf_test.yaml
+++ b/tests/waf_test.yaml
@@ -1,0 +1,67 @@
+suite: WAF
+templates:
+  - templates/waf.yaml 
+tests:
+  - it: should be disabled by default
+    set:
+      webApplicationFirewall.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+  - it: should be enabled when webApplicationFirewall.enabled is true
+    set:
+      webApplicationFirewall:
+        enabled: true
+        entries:
+          - name: testentry
+            hosts:
+              - hostname: example.com
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: WebApplicationFirewall
+      - matchRegex:
+          path: metadata.name
+          pattern: '-testentry$'
+      - equal:
+          path: spec.domains[0]
+          value: "example.com"
+  - it: should set web_acl_name when specified
+    set:
+      webApplicationFirewall:
+        enabled: true
+        entries:
+          - name: testentry
+            webAclName: "test-acl-name"
+    asserts:
+      - equal:
+          path: spec.web_acl_name
+          value: "test-acl-name"
+  - it: should set custom_certificate_secret_store_path when specified
+    set:
+      webApplicationFirewall:
+        enabled: true
+        entries:
+          - name: testentry
+            customCertificateSecretStorePath: "secret/path-in-secret-store"
+    asserts:
+      - equal:
+          path: spec.custom_certificate_secret_store_path
+          value: "secret/path-in-secret-store"
+  - it: should support multiple hostnames for a single WAF entry
+    set:
+      webApplicationFirewall:
+        enabled: true
+        entries:
+          - name: testentrymultihost
+            hosts:
+              - hostname: example1.com
+              - hostname: example2.com
+    asserts:
+      - equal:
+          path: spec.domains[0]
+          value: "example1.com"
+      - equal:
+          path: spec.domains[1]
+          value: "example2.com"

--- a/tests/waf_test.yaml
+++ b/tests/waf_test.yaml
@@ -4,13 +4,13 @@ templates:
 tests:
   - it: should be disabled by default
     set:
-      webApplicationFirewall.enabled: false
+      waf.enabled: false
     asserts:
       - hasDocuments:
           count: 0
-  - it: should be enabled when webApplicationFirewall.enabled is true
+  - it: should be enabled when waf.enabled is true
     set:
-      webApplicationFirewall:
+      waf:
         enabled: true
         entries:
           - name: testentry
@@ -29,7 +29,7 @@ tests:
           value: "example.com"
   - it: should set web_acl_name when specified
     set:
-      webApplicationFirewall:
+      waf:
         enabled: true
         entries:
           - name: testentry
@@ -40,7 +40,7 @@ tests:
           value: "test-acl-name"
   - it: should set custom_certificate_secret_store_path when specified
     set:
-      webApplicationFirewall:
+      waf:
         enabled: true
         entries:
           - name: testentry
@@ -51,7 +51,7 @@ tests:
           value: "secret/path-in-secret-store"
   - it: should support multiple hostnames for a single WAF entry
     set:
-      webApplicationFirewall:
+      waf:
         enabled: true
         entries:
           - name: testentrymultihost

--- a/values.yaml
+++ b/values.yaml
@@ -1021,3 +1021,29 @@ customResources:
   #     namespace: default
   #   data:
   #     myKey: myValue
+
+
+
+##########################################################
+# Web Application Firewall (WAF)
+##########################################################
+# -- WAF configuration
+webApplicationFirewall:
+  # -- Whether to create a WAF
+  enabled: false
+  # -- Entries for the WAFs. Each WAF can have multiple TLD's but will share the same certificate. Create multiple as you need.
+  entries:
+  #   - name: examplewafone
+  #     hosts:
+  #       - hostname: "example.com"
+  #       - hostname: "*.example.com" 
+  #     webAclName: "block-bad-networks-and-rate-limit" # Specify the Web ACL to use. 
+  # # -- Specify a certificate if you want to import it from the secret store.
+  #     customCertificateSecretStorePath: "" ## "secret/path-to-secret-in-secret-store"
+  #   - name: examplewaftwo
+  #     hosts:
+  #       - hostname: "exampletwo.com"
+  #       - hostname: "*.exampletwo.com" 
+  #     web_acl_name: "block-bad-networks-and-rate-limit" # Specify the Web ACL to use. 
+  # # -- Specify a certificate if you want to import it from the secret store.
+  #     customCertificateSecretStorePath: "" ## "secret/path-to-secret-in-secret-store"

--- a/values.yaml
+++ b/values.yaml
@@ -1028,7 +1028,7 @@ customResources:
 # Web Application Firewall (WAF)
 ##########################################################
 # -- WAF configuration
-webApplicationFirewall:
+waf:
   # -- Whether to create a WAF
   enabled: false
   # -- Entries for the WAFs. Each WAF can have multiple TLD's but will share the same certificate. Create multiple as you need.

--- a/values.yaml
+++ b/values.yaml
@@ -1044,6 +1044,6 @@ waf:
   #     hosts:
   #       - hostname: "exampletwo.com"
   #       - hostname: "*.exampletwo.com" 
-  #     web_acl_name: "block-bad-networks-and-rate-limit" # Specify the Web ACL to use. 
+  #     webAclName: "block-bad-networks-and-rate-limit" # Specify the Web ACL to use. 
   # # -- Specify a certificate if you want to import it from the secret store.
   #     customCertificateSecretStorePath: "" ## "secret/path-to-secret-in-secret-store"


### PR DESCRIPTION
chore: bump version for release 0.4.0
chore: bump verison of k3s from 1.27.2 -> 1.27.5 (matching EKS).
chore: bump version of external secrets 0.8.3 -> 0.9.5
chore: Polaris 8.0.0 -> 8.5.1
chore: kubeconform 0.6.2 -> 0.6.3
chore: kube score 1.16.1 -> 1.17.0
fix: Update polaris config. Commented out metadataAndNameMismatched as it appears to not exist at all and was probably being ignored on the older version. And added metadataAndInstanceMismatched as a warning since danger causes existing resources to fail.