### PR TITLE
docs(examples/deployment): comment out readOnly toggle for volumeMoun…

### DIFF
--- a/examples/deployment/values.yaml
+++ b/examples/deployment/values.yaml
@@ -215,7 +215,7 @@ deployment:
   volumeMounts:
   - name: foo
     mountPath: "/etc/foo"
-    readOnly: true
+    # readOnly: true # value does not apply to secrets
 
   # list of volumes in original k8s format.
   volumes:


### PR DESCRIPTION


> This app will be decommissioned on Dec 1st. Please remove this app and install [Qodo Git](https://github.com/marketplace/qodo-merge-pro).

### **User description**
…ts and add comment


___

### **PR Type**
Documentation


___

### **Description**
- Comment out `readOnly: true` in volumeMounts example

- Add clarifying comment explaining readOnly doesn't apply to secrets


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["volumeMounts config"] -- "comment out readOnly" --> B["readOnly: true commented"]
  B -- "add explanation" --> C["clarify secrets behavior"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>values.yaml</strong><dd><code>Comment out readOnly with clarifying note</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

examples/deployment/values.yaml

<ul><li>Commented out <code>readOnly: true</code> line in volumeMounts configuration<br> <li> Added inline comment explaining that readOnly value does not apply to <br>secrets<br> <li> Improves documentation clarity for deployment example</ul>


</details>


  </td>
  <td><a href="https://github.com/GlueOps/project-template-helm-chart-app/pull/88/files#diff-f965e9834d11b1aaeb14b38296da7385a7ae20b938e7cc80f0618bbc3a4d8c37">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



> The managed version of the open source project PR-Agent is sunsetting on the 1st December 2025. The commercial version of this project will remain available and free to use as a hosted service. [Install Qodo](https://github.com/marketplace/qodo-merge-pro).