### PR TITLE
feat: updating app.name to default to the helm Release.Name or be overridden by user with appName

### DIFF
--- a/.github/workflows/ci_test.yaml
+++ b/.github/workflows/ci_test.yaml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Install
         env:
-          KUBE_LINTER_VER: 0.7.6
+          KUBE_LINTER_VER: 0.6.4
           KUBE_SCORE_VER: 1.20.0
           POLARIS_VER: 10.1.3
           KUBECONFORM_VER: 0.7.0

--- a/.github/workflows/ci_test.yaml
+++ b/.github/workflows/ci_test.yaml
@@ -14,8 +14,8 @@ jobs:
           # - k3s release channels at https://github.com/k3s-io/k3s/blob/HEAD/channel.yaml
           # - k3s versions at https://github.com/k3s-io/k3s/tags
           # - helm versions at https://github.com/helm/helm/tags
-          k3s-version: v1.32.9+k3s1
-          helm-version: v3.16.2
+          k3s-version: v1.32.10+k3s1
+          helm-version: v3.19.2
           metrics-enabled: false
           traefik-enabled: false
 
@@ -30,10 +30,10 @@ jobs:
 
       - name: Install
         env:
-          KUBE_LINTER_VER: 0.6.4
-          KUBE_SCORE_VER: 1.17.0
-          POLARIS_VER: 8.5.1
-          KUBECONFORM_VER: 0.6.3
+          KUBE_LINTER_VER: 0.7.6
+          KUBE_SCORE_VER: 1.20.0
+          POLARIS_VER: 10.1.3
+          KUBECONFORM_VER: 0.7.0
         run: |
           sudo apt-get update -yqq
           sudo apt-get install -yqq yamllint wget

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,4 +1,4 @@
 name: app
 apiVersion: v2
 description: A Helm chart template for applications
-version: 0.9.0-rc3
+version: 0.9.0-rc4

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,4 +1,4 @@
 name: app
 apiVersion: v2
 description: A Helm chart template for applications
-version: 0.9.0-rc2
+version: 0.9.0-rc3

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,4 +1,4 @@
 name: app
 apiVersion: v2
 description: A Helm chart template for applications
-version: 0.9.0-rc4
+version: 0.9.0-rc5

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,4 +1,4 @@
 name: app
 apiVersion: v2
 description: A Helm chart template for applications
-version: 0.8.1
+version: 0.9.0-rc2

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ lint:
 	helm lint
 
 unittest:
-	helm unittest . 
+	helm unittest . --set appName="example-app"
 
 test:
 	cd examples && bash test.sh

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ lint:
 	helm lint
 
 unittest:
-	helm unittest  . 
+	helm unittest --name-template example-app . 
 
 test:
 	cd examples && bash test.sh

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ lint:
 	helm lint
 
 unittest:
-	helm unittest . --set appName="example-app"
+	helm unittest .
 
 test:
 	cd examples && bash test.sh

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ lint:
 	helm lint
 
 unittest:
-	helm unittest --name-template example-app . 
+	helm unittest --release-name example-app . 
 
 test:
 	cd examples && bash test.sh

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ lint:
 	helm lint
 
 unittest:
-	helm unittest --release-name example-app . 
+	helm unittest . 
 
 test:
 	cd examples && bash test.sh

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # app
 
-![Version: 0.9.0-rc3](https://img.shields.io/badge/Version-0.9.0--rc3-informational?style=flat-square)
+![Version: 0.9.0-rc4](https://img.shields.io/badge/Version-0.9.0--rc4-informational?style=flat-square)
 
 A Helm chart template for applications
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@ A Helm chart template for applications
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | appEnv | string | `"dev"` | Environment of the application |
-| appName | string | `"example-app"` | Name of the application |
 | appVersion | string | `"0.0.1"` | Version of the application |
 | commonAnnotations | string | `nil` | Common annotations for all Kubernetes objects |
 | commonLabels | string | `nil` | Common labels for all Kubernetes objects |

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # app
 
-![Version: 0.9.0-rc4](https://img.shields.io/badge/Version-0.9.0--rc4-informational?style=flat-square)
+![Version: 0.9.0-rc5](https://img.shields.io/badge/Version-0.9.0--rc5-informational?style=flat-square)
 
 A Helm chart template for applications
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A Helm chart template for applications
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | appEnv | string | `"dev"` | Environment of the application |
-| appName | string | `"nil"` | Name of the application |
+| appName | string | `""` | Name of the application |
 | appVersion | string | `"0.0.1"` | Version of the application |
 | commonAnnotations | string | `nil` | Common annotations for all Kubernetes objects |
 | commonLabels | string | `nil` | Common labels for all Kubernetes objects |

--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@ A Helm chart template for applications
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | appEnv | string | `"dev"` | Environment of the application |
-| appName | string | `""` | Name of the application |
 | appVersion | string | `"0.0.1"` | Version of the application |
 | commonAnnotations | string | `nil` | Common annotations for all Kubernetes objects |
 | commonLabels | string | `nil` | Common labels for all Kubernetes objects |

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ A Helm chart template for applications
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | appEnv | string | `"dev"` | Environment of the application |
+| appName | string | `"nil"` | Name of the application |
 | appVersion | string | `"0.0.1"` | Version of the application |
 | commonAnnotations | string | `nil` | Common annotations for all Kubernetes objects |
 | commonLabels | string | `nil` | Common labels for all Kubernetes objects |

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # app
 
-![Version: 0.8.1](https://img.shields.io/badge/Version-0.8.1-informational?style=flat-square)
+![Version: 0.9.0-rc2](https://img.shields.io/badge/Version-0.9.0--rc2-informational?style=flat-square)
 
 A Helm chart template for applications
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # app
 
-![Version: 0.9.0-rc2](https://img.shields.io/badge/Version-0.9.0--rc2-informational?style=flat-square)
+![Version: 0.9.0-rc3](https://img.shields.io/badge/Version-0.9.0--rc3-informational?style=flat-square)
 
 A Helm chart template for applications
 

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -10,7 +10,7 @@ Create chart name and version as used by the chart label.
 Define the name of the chart/application.
 */}}
 {{- define "app.name" -}}
-{{- .Values.appName | default .Values.glueops_app_name | default .Chart.Name | trunc 63 | trimSuffix "-" -}}
+{{- .Values.appName | default .Release.Name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{/*

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -10,7 +10,7 @@ Create chart name and version as used by the chart label.
 Define the name of the chart/application.
 */}}
 {{- define "app.name" -}}
-{{- .Values.appName | default .Chart.Name  | trunc 63 | trimSuffix "-" -}}
+{{- .Values.appName | default .Values.glueops_app_name | default .Chart.Name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{/*

--- a/tests/configmap_test.yaml
+++ b/tests/configmap_test.yaml
@@ -2,6 +2,8 @@ suite: Configmap
 
 templates:
   - templates/configmap.yaml
+set:
+  appName: "example-app"
 
 tests:
   - it: should not create configmap when disabled

--- a/tests/cronjob_test.yaml
+++ b/tests/cronjob_test.yaml
@@ -1,6 +1,9 @@
 suite: CronJob
 templates:
   - cronjob.yaml
+set:
+  appName: "example-app"
+
 tests:
   - it: should be disabled by default
     set:

--- a/tests/deployment_test.yaml
+++ b/tests/deployment_test.yaml
@@ -2,6 +2,8 @@ suite: Deployment
 
 templates:
   - templates/deployment.yaml
+set:
+  appName: "example-app"
 
 tests:
   - it: does not fail to render when image tag not given

--- a/tests/externalsecret_test.yaml
+++ b/tests/externalsecret_test.yaml
@@ -1,6 +1,9 @@
 suite: ExternalSecret
 templates:
   - templates/externalsecret.yaml
+set:
+  appName: "example-app"
+
 tests:
   - it: should create an ExternalSecret
     set:

--- a/tests/ingress_test.yaml
+++ b/tests/ingress_test.yaml
@@ -1,6 +1,9 @@
 suite: Ingress
 templates:
   - templates/ingress.yaml
+set:
+  appName: "example-app"
+  
 tests:
   - it: should render nothing if not enabled
     asserts:

--- a/tests/ingress_test.yaml
+++ b/tests/ingress_test.yaml
@@ -3,7 +3,7 @@ templates:
   - templates/ingress.yaml
 set:
   appName: "example-app"
-  
+
 tests:
   - it: should render nothing if not enabled
     asserts:

--- a/tests/job_test.yaml
+++ b/tests/job_test.yaml
@@ -1,6 +1,9 @@
 suite: Job
 templates:
   - job.yaml
+set:
+  appName: "example-app"
+
 tests:
   - it: should not create a job by default
     set:

--- a/tests/keda_scaledobject_test.yaml
+++ b/tests/keda_scaledobject_test.yaml
@@ -4,7 +4,7 @@ templates:
   - templates/keda-scaledObject.yaml
 set:
   appName: "example-app"
-  
+
 tests:
   # Test Case 1: Check if KEDA is disabled by default
   - it: should not have KEDA enabled by default

--- a/tests/keda_scaledobject_test.yaml
+++ b/tests/keda_scaledobject_test.yaml
@@ -2,7 +2,9 @@ suite: Keda ScaledObject
 
 templates:
   - templates/keda-scaledObject.yaml
-
+set:
+  appName: "example-app"
+  
 tests:
   # Test Case 1: Check if KEDA is disabled by default
   - it: should not have KEDA enabled by default

--- a/tests/keda_triggerauthentication_test.yaml
+++ b/tests/keda_triggerauthentication_test.yaml
@@ -2,7 +2,9 @@ suite: Keda TriggerAuthentication
 
 templates:
   - templates/keda-triggerAuthentication.yaml
-
+set:
+  appName: "example-app"
+  
 tests:
   # Test Case 5: Check if Kafka triggerAuthentication is disabled by default
   - it: should not have Kafka triggerAuthentication enabled by default

--- a/tests/keda_triggerauthentication_test.yaml
+++ b/tests/keda_triggerauthentication_test.yaml
@@ -4,7 +4,7 @@ templates:
   - templates/keda-triggerAuthentication.yaml
 set:
   appName: "example-app"
-  
+
 tests:
   # Test Case 5: Check if Kafka triggerAuthentication is disabled by default
   - it: should not have Kafka triggerAuthentication enabled by default

--- a/tests/pdb_test.yaml
+++ b/tests/pdb_test.yaml
@@ -2,7 +2,9 @@ suite: PodDisruptionBudget
 
 templates:
   - templates/pdb.yaml
-
+set:
+  appName: "example-app"
+  
 tests:
   - it: does not yield PDB if disabled
     set:

--- a/tests/pdb_test.yaml
+++ b/tests/pdb_test.yaml
@@ -4,7 +4,7 @@ templates:
   - templates/pdb.yaml
 set:
   appName: "example-app"
-  
+
 tests:
   - it: does not yield PDB if disabled
     set:

--- a/tests/pvc_test.yaml
+++ b/tests/pvc_test.yaml
@@ -1,6 +1,8 @@
 suite: persistentVolumeClaim
 templates:
   - pvc.yaml
+set:
+  appName: "example-app"
 tests:
   - it: should not create PVC when enabled is false
     set:

--- a/tests/service_test.yaml
+++ b/tests/service_test.yaml
@@ -1,6 +1,8 @@
 suite: Service
 templates:
   - templates/service.yaml
+set:
+  appName: "example-app"
 tests:
   - it: should not create a service if service is not enabled
     set:

--- a/tests/serviceaccount_test.yaml
+++ b/tests/serviceaccount_test.yaml
@@ -2,7 +2,8 @@ suite: ServiceAccount
 
 templates:
   - templates/serviceaccount.yaml
-
+set:
+  appName: "example-app"
 tests:
   - it: does not yield resource if ServiceAccount is disabled
     set:

--- a/tests/statefulset_test.yaml
+++ b/tests/statefulset_test.yaml
@@ -1,6 +1,8 @@
 suite: StatefulSet
 templates:
   - templates/statefulset.yaml
+set:
+  appName: "example-app"
 tests:
   - it: should use the correct image
     set:

--- a/tests/values.yaml
+++ b/tests/values.yaml
@@ -1,1 +1,0 @@
-appName: "example-app"

--- a/tests/values.yaml
+++ b/tests/values.yaml
@@ -1,0 +1,1 @@
+appName: "example-app"

--- a/values.yaml
+++ b/values.yaml
@@ -1,5 +1,5 @@
 # -- Name of the application
-appName: "" # "example-app"
+# appName: "example-app"
 # -- Version of the application
 appVersion: "0.0.1"
 # -- Environment of the application

--- a/values.yaml
+++ b/values.yaml
@@ -1,5 +1,5 @@
 # -- Name of the application
-appName: "example-app"
+# appName: "example-app"
 # -- Version of the application
 appVersion: "0.0.1"
 # -- Environment of the application

--- a/values.yaml
+++ b/values.yaml
@@ -1,5 +1,5 @@
 # -- Name of the application
-appName: nil
+appName: "" # "example-app"
 # -- Version of the application
 appVersion: "0.0.1"
 # -- Environment of the application

--- a/values.yaml
+++ b/values.yaml
@@ -1,5 +1,5 @@
 # -- Name of the application
-# appName: "example-app"
+appName: nil
 # -- Version of the application
 appVersion: "0.0.1"
 # -- Environment of the application


### PR DESCRIPTION
Currently we specify the appName in our appset definition for the customer so that it defaults to the Release.Name, Because of how helm values files work the customer is unable to override the value if we specify it in our appset definition and if we don't specify it all their apps will run into a naming conflict. As a result this chart will now use the default of "Release.Name" as the app.name otherwise if appName is provided by the customer that will be used.


### Deployment plan:

In the same commit:
- Update chart version from 0.8.1 -> 0.9.0 (non-RC needs to be cut after this is merged to main)
- Confirm appName in the appSet is matching the Release.Name, if so, comment it out/delete it. If it's not the same, there may be downtime and the change needs to be coordinated with customer
<img width="777" height="436" alt="image" src="https://github.com/user-attachments/assets/5830e895-ca11-4bd8-a9eb-97b1ecf5ecd0" />


# WARNING:

This will cause all pods to get rolled. So it's best to do this off hours. Opsgenie may alert for a few minutes because of high cpu from the argocd app controller services

To test use version: `0.9.0-rc5`

# Reminder: 

infra cluster is currently running with 0.9.0-rc5. Switch it over to the final version as this gets merged/released.
