### PR TITLE
fix: render externalSecret remoteRef fields as yaml

### DIFF
--- a/examples/externalsecret/values.yaml
+++ b/examples/externalsecret/values.yaml
@@ -13,7 +13,7 @@ externalSecret:
             key: monodb
             property: password
             version: "AWSCURRENT"
-            decodingStrategy: None
+            decodingStrategy: "None"
       secretStore:                       
         name: secret-store-name-2    # specify if value is other than default secretstore  
       labels:

--- a/examples/externalsecret/values.yaml
+++ b/examples/externalsecret/values.yaml
@@ -12,7 +12,7 @@ externalSecret:
           remoteRef: 
             key: monodb
             property: password
-            version: AWSCURRENT
+            version: "AWSCURRENT"
             decodingStrategy: None
       secretStore:                       
         name: secret-store-name-2    # specify if value is other than default secretstore  

--- a/examples/externalsecret/values.yaml
+++ b/examples/externalsecret/values.yaml
@@ -11,7 +11,9 @@ externalSecret:
         mongo-password: 
           remoteRef: 
             key: monodb
-            property: password 
+            property: password
+            version: AWSCURRENT
+            decodingStrategy: None
       secretStore:                       
         name: secret-store-name-2    # specify if value is other than default secretstore  
       labels:

--- a/examples/externalsecret/values.yaml
+++ b/examples/externalsecret/values.yaml
@@ -10,7 +10,7 @@ externalSecret:
       data:
         mongo-password: 
           remoteRef: 
-            key: monodb
+            key: mongodb
             property: password
             version: "AWSCURRENT"
             decodingStrategy: "None"

--- a/templates/externalsecret.yaml
+++ b/templates/externalsecret.yaml
@@ -27,9 +27,13 @@ spec:
     {{- if not (hasKey $secretProperty.remoteRef "key") }}
     {{- fail (printf "remoteRef.key is required for secretKey %s in secret %s-%s" $secretKey (include "app.name" $) $nameSuffix) }}
     {{- end }}
-    {{- $remoteRefKey := (get $secretProperty.remoteRef "key" | toString | trim) }}
+    {{- $remoteRefKeyRaw := get $secretProperty.remoteRef "key" }}
+    {{- if not (kindIs "string" $remoteRefKeyRaw) }}
+    {{- fail (printf "remoteRef.key must be a non-empty string for secretKey %s in secret %s-%s" $secretKey (include "app.name" $) $nameSuffix) }}
+    {{- end }}
+    {{- $remoteRefKey := ($remoteRefKeyRaw | trim) }}
     {{- if eq $remoteRefKey "" }}
-    {{- fail (printf "remoteRef.key must be non-empty for secretKey %s in secret %s-%s" $secretKey (include "app.name" $) $nameSuffix) }}
+    {{- fail (printf "remoteRef.key must be a non-empty string for secretKey %s in secret %s-%s" $secretKey (include "app.name" $) $nameSuffix) }}
     {{- end }}
     - secretKey: {{ $secretKey }}
       remoteRef:

--- a/templates/externalsecret.yaml
+++ b/templates/externalsecret.yaml
@@ -20,8 +20,7 @@ spec:
   {{- range $secretKey, $secretProperty := $data.data}}
     - secretKey: {{ $secretKey }}
       remoteRef:
-        key: {{ $secretProperty.remoteRef.key }}
-        property: {{ $secretProperty.remoteRef.property }}
+{{- toYaml $secretProperty.remoteRef | nindent 8 }}
   {{- end }}
   {{- end }}
   {{- if and $data.dataFrom (hasKey $data.dataFrom "key") }}

--- a/templates/externalsecret.yaml
+++ b/templates/externalsecret.yaml
@@ -18,6 +18,12 @@ spec:
   {{- if $data.data }}
   data:
   {{- range $secretKey, $secretProperty := $data.data}}
+    {{- if not $secretProperty.remoteRef }}
+    {{- fail (printf "remoteRef is required for secretKey %s in secret %s-%s" $secretKey (include "app.name" $) $nameSuffix) }}
+    {{- end }}
+    {{- if not (hasKey $secretProperty.remoteRef "key") }}
+    {{- fail (printf "remoteRef.key is required for secretKey %s in secret %s-%s" $secretKey (include "app.name" $) $nameSuffix) }}
+    {{- end }}
     - secretKey: {{ $secretKey }}
       remoteRef:
         # Common remoteRef fields include:

--- a/templates/externalsecret.yaml
+++ b/templates/externalsecret.yaml
@@ -35,9 +35,7 @@ spec:
     {{- if eq $remoteRefKey "" }}
     {{- fail (printf "remoteRef.key must be non-empty for secretKey %s in secret %s-%s" $secretKey (include "app.name" $) $nameSuffix) }}
     {{- end }}
-    {{- if ne $remoteRefKey $remoteRefKeyRaw }}
-    {{- fail (printf "remoteRef.key must not have surrounding whitespace for secretKey %s in secret %s-%s" $secretKey (include "app.name" $) $nameSuffix) }}
-    {{- end }}
+    {{- $sanitizedRemoteRef := merge (dict "key" $remoteRefKey) (omit $secretProperty.remoteRef "key") }}
     - secretKey: {{ $secretKey }}
       remoteRef:
         # Common remoteRef fields include:
@@ -47,7 +45,7 @@ spec:
         # - decodingStrategy: How to decode the fetched value before writing the Kubernetes Secret.
         # - metadataPolicy: Whether to fetch provider metadata in addition to the secret value, when supported.
         # Additional provider- or ESO-specific fields may also be passed through below.
-        {{- toYaml $secretProperty.remoteRef | nindent 8 }}
+        {{- toYaml $sanitizedRemoteRef | nindent 8 }}
   {{- end }}
   {{- end }}
   {{- if and $data.dataFrom (hasKey $data.dataFrom "key") }}

--- a/templates/externalsecret.yaml
+++ b/templates/externalsecret.yaml
@@ -20,12 +20,13 @@ spec:
   {{- range $secretKey, $secretProperty := $data.data}}
     - secretKey: {{ $secretKey }}
       remoteRef:
-        # Supported remoteRef fields:
+        # Common remoteRef fields include:
         # - key: External provider secret name or path to read from.
         # - property: Specific field within the remote secret; use when the secret contains multiple values.
         # - version: Specific remote secret version to read; use when you need a fixed version instead of the latest.
         # - decodingStrategy: How to decode the fetched value before writing the Kubernetes Secret.
         # - metadataPolicy: Whether to fetch provider metadata in addition to the secret value, when supported.
+        # Additional provider- or ESO-specific fields may also be passed through below.
 {{- toYaml $secretProperty.remoteRef | nindent 8 }}
   {{- end }}
   {{- end }}

--- a/templates/externalsecret.yaml
+++ b/templates/externalsecret.yaml
@@ -29,7 +29,7 @@ spec:
     {{- end }}
     {{- $remoteRefKeyRaw := get $secretProperty.remoteRef "key" }}
     {{- if not (kindIs "string" $remoteRefKeyRaw) }}
-    {{- fail (printf "remoteRef.key must be non-empty for secretKey %s in secret %s-%s" $secretKey (include "app.name" $) $nameSuffix) }}
+    {{- fail (printf "remoteRef.key must be a string for secretKey %s in secret %s-%s" $secretKey (include "app.name" $) $nameSuffix) }}
     {{- end }}
     {{- $remoteRefKey := ($remoteRefKeyRaw | trim) }}
     {{- if eq $remoteRefKey "" }}

--- a/templates/externalsecret.yaml
+++ b/templates/externalsecret.yaml
@@ -21,8 +21,15 @@ spec:
     {{- if not $secretProperty.remoteRef }}
     {{- fail (printf "remoteRef is required for secretKey %s in secret %s-%s" $secretKey (include "app.name" $) $nameSuffix) }}
     {{- end }}
+    {{- if not (kindIs "map" $secretProperty.remoteRef) }}
+    {{- fail (printf "remoteRef must be a map for secretKey %s in secret %s-%s" $secretKey (include "app.name" $) $nameSuffix) }}
+    {{- end }}
     {{- if not (hasKey $secretProperty.remoteRef "key") }}
     {{- fail (printf "remoteRef.key is required for secretKey %s in secret %s-%s" $secretKey (include "app.name" $) $nameSuffix) }}
+    {{- end }}
+    {{- $remoteRefKey := (get $secretProperty.remoteRef "key" | toString | trim) }}
+    {{- if eq $remoteRefKey "" }}
+    {{- fail (printf "remoteRef.key must be non-empty for secretKey %s in secret %s-%s" $secretKey (include "app.name" $) $nameSuffix) }}
     {{- end }}
     - secretKey: {{ $secretKey }}
       remoteRef:
@@ -33,7 +40,7 @@ spec:
         # - decodingStrategy: How to decode the fetched value before writing the Kubernetes Secret.
         # - metadataPolicy: Whether to fetch provider metadata in addition to the secret value, when supported.
         # Additional provider- or ESO-specific fields may also be passed through below.
-{{- toYaml $secretProperty.remoteRef | nindent 8 }}
+        {{- toYaml $secretProperty.remoteRef | nindent 8 }}
   {{- end }}
   {{- end }}
   {{- if and $data.dataFrom (hasKey $data.dataFrom "key") }}

--- a/templates/externalsecret.yaml
+++ b/templates/externalsecret.yaml
@@ -20,6 +20,12 @@ spec:
   {{- range $secretKey, $secretProperty := $data.data}}
     - secretKey: {{ $secretKey }}
       remoteRef:
+        # Supported remoteRef fields:
+        # - key: External provider secret name or path to read from.
+        # - property: Specific field within the remote secret; use when the secret contains multiple values.
+        # - version: Specific remote secret version to read; use when you need a fixed version instead of the latest.
+        # - decodingStrategy: How to decode the fetched value before writing the Kubernetes Secret.
+        # - metadataPolicy: Whether to fetch provider metadata in addition to the secret value, when supported.
 {{- toYaml $secretProperty.remoteRef | nindent 8 }}
   {{- end }}
   {{- end }}

--- a/templates/externalsecret.yaml
+++ b/templates/externalsecret.yaml
@@ -33,7 +33,10 @@ spec:
     {{- end }}
     {{- $remoteRefKey := ($remoteRefKeyRaw | trim) }}
     {{- if eq $remoteRefKey "" }}
-    {{- fail (printf "remoteRef.key must be a non-empty string for secretKey %s in secret %s-%s" $secretKey (include "app.name" $) $nameSuffix) }}
+    {{- fail (printf "remoteRef.key must be non-empty for secretKey %s in secret %s-%s" $secretKey (include "app.name" $) $nameSuffix) }}
+    {{- end }}
+    {{- if ne $remoteRefKey $remoteRefKeyRaw }}
+    {{- fail (printf "remoteRef.key must not have surrounding whitespace for secretKey %s in secret %s-%s" $secretKey (include "app.name" $) $nameSuffix) }}
     {{- end }}
     - secretKey: {{ $secretKey }}
       remoteRef:

--- a/templates/externalsecret.yaml
+++ b/templates/externalsecret.yaml
@@ -29,11 +29,11 @@ spec:
     {{- end }}
     {{- $remoteRefKeyRaw := get $secretProperty.remoteRef "key" }}
     {{- if not (kindIs "string" $remoteRefKeyRaw) }}
-    {{- fail (printf "remoteRef.key must be a non-empty string for secretKey %s in secret %s-%s" $secretKey (include "app.name" $) $nameSuffix) }}
+    {{- fail (printf "remoteRef.key must be non-empty for secretKey %s in secret %s-%s" $secretKey (include "app.name" $) $nameSuffix) }}
     {{- end }}
     {{- $remoteRefKey := ($remoteRefKeyRaw | trim) }}
     {{- if eq $remoteRefKey "" }}
-    {{- fail (printf "remoteRef.key must be a non-empty string for secretKey %s in secret %s-%s" $secretKey (include "app.name" $) $nameSuffix) }}
+    {{- fail (printf "remoteRef.key must be non-empty for secretKey %s in secret %s-%s" $secretKey (include "app.name" $) $nameSuffix) }}
     {{- end }}
     - secretKey: {{ $secretKey }}
       remoteRef:

--- a/tests/externalsecret_test.yaml
+++ b/tests/externalsecret_test.yaml
@@ -122,3 +122,30 @@ tests:
     asserts:
       - failedTemplate:
           errorMessage: "remoteRef.key is required for secretKey missing-key in secret example-app-name5"
+
+  - it: should fail when remoteRef is not a map
+    set:
+      externalSecret:
+        enabled: true
+        secrets:
+          name6:
+            data:
+              wrong-type:
+                remoteRef: invalid-scalar
+    asserts:
+      - failedTemplate:
+          errorMessage: "remoteRef must be a map for secretKey wrong-type in secret example-app-name6"
+
+  - it: should fail when remoteRef.key is empty
+    set:
+      externalSecret:
+        enabled: true
+        secrets:
+          name7:
+            data:
+              empty-key:
+                remoteRef:
+                  key: ""
+    asserts:
+      - failedTemplate:
+          errorMessage: "remoteRef.key must be non-empty for secretKey empty-key in secret example-app-name7"

--- a/tests/externalsecret_test.yaml
+++ b/tests/externalsecret_test.yaml
@@ -96,3 +96,29 @@ tests:
       - equal:
           path: spec.data[0].remoteRef.metadataPolicy
           value: "None"
+
+  - it: should fail when remoteRef is missing
+    set:
+      externalSecret:
+        enabled: true
+        secrets:
+          name4:
+            data:
+              missing-remote-ref: {}
+    asserts:
+      - failedTemplate:
+          errorMessage: "remoteRef is required for secretKey missing-remote-ref in secret example-app-name4"
+
+  - it: should fail when remoteRef.key is missing
+    set:
+      externalSecret:
+        enabled: true
+        secrets:
+          name5:
+            data:
+              missing-key:
+                remoteRef:
+                  property: only-property
+    asserts:
+      - failedTemplate:
+          errorMessage: "remoteRef.key is required for secretKey missing-key in secret example-app-name5"

--- a/tests/externalsecret_test.yaml
+++ b/tests/externalsecret_test.yaml
@@ -148,4 +148,4 @@ tests:
                   key: ""
     asserts:
       - failedTemplate:
-          errorMessage: "remoteRef.key must be non-empty for secretKey empty-key in secret example-app-name7"
+          errorMessage: "remoteRef.key must be a non-empty string for secretKey empty-key in secret example-app-name7"

--- a/tests/externalsecret_test.yaml
+++ b/tests/externalsecret_test.yaml
@@ -57,3 +57,42 @@ tests:
       - equal:
           path: spec.dataFrom[0].extract.key
           value: "postgres"
+
+  - it: should render all configured remoteRef fields
+    set:
+      externalSecret:
+        enabled: true
+        secrets:
+          name3:
+            data:
+              token:
+                remoteRef:
+                  key: key3
+                  property: property3
+                  version: "AWSCURRENT"
+                  decodingStrategy: None
+                  metadataPolicy: None
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: metadata.name
+          value: "example-app-name3"
+      - equal:
+          path: spec.data[0].secretKey
+          value: "token"
+      - equal:
+          path: spec.data[0].remoteRef.key
+          value: "key3"
+      - equal:
+          path: spec.data[0].remoteRef.property
+          value: "property3"
+      - equal:
+          path: spec.data[0].remoteRef.version
+          value: "AWSCURRENT"
+      - equal:
+          path: spec.data[0].remoteRef.decodingStrategy
+          value: "None"
+      - equal:
+          path: spec.data[0].remoteRef.metadataPolicy
+          value: "None"

--- a/tests/externalsecret_test.yaml
+++ b/tests/externalsecret_test.yaml
@@ -150,7 +150,7 @@ tests:
       - failedTemplate:
           errorMessage: "remoteRef.key must be non-empty for secretKey empty-key in secret example-app-name7"
 
-  - it: should fail when remoteRef.key has surrounding whitespace
+  - it: should trim surrounding whitespace from remoteRef.key
     set:
       externalSecret:
         enabled: true
@@ -161,5 +161,6 @@ tests:
                 remoteRef:
                   key: "  mykey  "
     asserts:
-      - failedTemplate:
-          errorMessage: "remoteRef.key must not have surrounding whitespace for secretKey whitespace-key in secret example-app-name8"
+      - equal:
+          path: spec.data[0].remoteRef.key
+          value: "mykey"

--- a/tests/externalsecret_test.yaml
+++ b/tests/externalsecret_test.yaml
@@ -149,3 +149,17 @@ tests:
     asserts:
       - failedTemplate:
           errorMessage: "remoteRef.key must be non-empty for secretKey empty-key in secret example-app-name7"
+
+  - it: should fail when remoteRef.key has surrounding whitespace
+    set:
+      externalSecret:
+        enabled: true
+        secrets:
+          name8:
+            data:
+              whitespace-key:
+                remoteRef:
+                  key: "  mykey  "
+    asserts:
+      - failedTemplate:
+          errorMessage: "remoteRef.key must not have surrounding whitespace for secretKey whitespace-key in secret example-app-name8"

--- a/tests/externalsecret_test.yaml
+++ b/tests/externalsecret_test.yaml
@@ -136,26 +136,40 @@ tests:
       - failedTemplate:
           errorMessage: "remoteRef must be a map for secretKey wrong-type in secret example-app-name6"
 
-  - it: should fail when remoteRef.key is empty
+  - it: should fail when remoteRef.key is not a string
     set:
       externalSecret:
         enabled: true
         secrets:
           name7:
             data:
+              int-key:
+                remoteRef:
+                  key: 12345
+    asserts:
+      - failedTemplate:
+          errorMessage: "remoteRef.key must be a string for secretKey int-key in secret example-app-name7"
+
+  - it: should fail when remoteRef.key is empty
+    set:
+      externalSecret:
+        enabled: true
+        secrets:
+          name8:
+            data:
               empty-key:
                 remoteRef:
                   key: ""
     asserts:
       - failedTemplate:
-          errorMessage: "remoteRef.key must be non-empty for secretKey empty-key in secret example-app-name7"
+          errorMessage: "remoteRef.key must be non-empty for secretKey empty-key in secret example-app-name8"
 
   - it: should trim surrounding whitespace from remoteRef.key
     set:
       externalSecret:
         enabled: true
         secrets:
-          name8:
+          name9:
             data:
               whitespace-key:
                 remoteRef:

--- a/values.yaml
+++ b/values.yaml
@@ -893,7 +893,7 @@ externalSecret:
     #     mongo-password:
     #       envName: MONGO_PASSWORD
     #       remoteRef:
-    #         key: monodb
+    #         key: mongodb
     #         property: password
     #         version: 'AWSCURRENT'
     #   secretStore:

--- a/values.yaml
+++ b/values.yaml
@@ -895,7 +895,7 @@ externalSecret:
     #       remoteRef:
     #         key: monodb
     #         property: password
-    #         version: AWSCURRENT
+    #         version: 'AWSCURRENT'
     #   secretStore:
     #     name: secret-store-name-2    # specify if value is other than default secretstore
     #   labels:

--- a/values.yaml
+++ b/values.yaml
@@ -895,6 +895,7 @@ externalSecret:
     #       remoteRef:
     #         key: monodb
     #         property: password
+    #         version: AWSCURRENT
     #   secretStore:
     #     name: secret-store-name-2    # specify if value is other than default secretstore
     #   labels:


### PR DESCRIPTION
https://github.com/internal-GlueOps/issues/issues/318

Summary
This PR fixes ExternalSecret drift caused by partial remoteRef rendering in the chart template.

Today, only remoteRef.key and remoteRef.property are rendered. Any additional remoteRef fields configured in values are dropped, and External Secrets Operator may mutate/default them in-cluster, which leads to recurring Argo CD OutOfSync.

This change renders the full remoteRef object as YAML so provider-specific fields are preserved.

Problem
ExternalSecret spec.data[].remoteRef was hardcoded to key/property only.
Additional fields (for example AWS-specific or ESO-supported remoteRef fields) were not represented in desired state.
ESO reconciliation could mutate/live-default those fields, creating persistent Argo CD drift.
Fix
Render remoteRef as pass-through YAML from values instead of fixed key/property fields.
Keep backward compatibility for existing key/property-only configurations.
Add unit test coverage for extra remoteRef fields.
Update values/examples to demonstrate extended remoteRef usage.
Files changed
externalsecret.yaml
externalsecret_test.yaml
values.yaml
values.yaml
Regression safety
Existing ExternalSecret unit tests remain in place.
dataFrom behavior is unchanged and still covered by tests.
Legacy key/property-only remoteRef behavior remains supported.
Verified chart renders cleanly with extended remoteRef fields.
Unit tests
Ran helm unittest for the chart.
Result: all suites passed, including ExternalSecret coverage with new assertions for additional remoteRef fields.